### PR TITLE
feat: add keepalive workflow to prevent GitHub disabling scheduled jobs

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -2,7 +2,7 @@ name: Keepalive
 
 on:
   schedule:
-    - cron: '0 0 1 1,3,5,7,9,11 *'  # 1st of every other month
+    - cron: '0 0 1 1,3,5,7,9,11 *'  # Jan, Mar, May, Jul, Sep, Nov - every ~2 months
   workflow_dispatch:
 
 jobs:
@@ -13,12 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Empty commit to keep repo active
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit --allow-empty -m "chore: keepalive"
-          git push
+          git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,24 @@
+name: Keepalive
+
+on:
+  schedule:
+    - cron: '0 0 1 1,3,5,7,9,11 *'  # 1st of every other month
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Empty commit to keep repo active
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore: keepalive"
+          git push

--- a/docs/plans/2026-04-12-keepalive-workflow-design.md
+++ b/docs/plans/2026-04-12-keepalive-workflow-design.md
@@ -1,0 +1,33 @@
+# Keepalive Workflow Design
+
+**Date:** 2026-04-12  
+**Problem:** GitHub disables scheduled workflows after 60 days of repository inactivity (no pushes). The `index.yml` workflow uploads release assets but never commits, so the repo goes inactive.
+
+## Solution
+
+Add a dedicated keepalive workflow that makes an empty commit every ~60 days to keep the repository active.
+
+## File
+
+`.github/workflows/keepalive.yml`
+
+## Schedule
+
+`0 0 1 1,3,5,7,9,11 *` — runs on the 1st of every other month (January, March, May, July, September, November), giving ~60 day intervals.
+
+## Logic
+
+1. Checkout repo with a token that allows push
+2. `git commit --allow-empty -m "chore: keepalive"`
+3. `git push`
+
+## Permissions
+
+- `contents: write` — same as `index.yml`
+- Uses `GITHUB_TOKEN` from the runner — no additional secrets required
+
+## Trade-offs
+
+- Adds empty commits to the git history (acceptable, clearly labeled)
+- No external dependencies
+- Transparent and easy to understand

--- a/docs/plans/2026-04-12-keepalive-workflow.md
+++ b/docs/plans/2026-04-12-keepalive-workflow.md
@@ -1,0 +1,62 @@
+# Keepalive Workflow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a GitHub Actions workflow that makes an empty commit every ~60 days to prevent GitHub from disabling scheduled workflows due to repository inactivity.
+
+**Architecture:** A single new workflow file `.github/workflows/keepalive.yml` that runs on a bimonthly schedule and executes `git commit --allow-empty` + `git push` using the built-in `GITHUB_TOKEN`.
+
+**Tech Stack:** GitHub Actions, bash
+
+---
+
+### Task 1: Create the keepalive workflow file
+
+**Files:**
+- Create: `.github/workflows/keepalive.yml`
+
+**Step 1: Create the workflow file**
+
+```yaml
+name: Keepalive
+
+on:
+  schedule:
+    - cron: '0 0 1 1,3,5,7,9,11 *'  # 1st of every other month
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Empty commit to keep repo active
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore: keepalive"
+          git push
+```
+
+**Step 2: Verify the file is valid YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/keepalive.yml'))" && echo OK`
+Expected: `OK`
+
+**Step 3: Commit and push**
+
+```bash
+git add .github/workflows/keepalive.yml
+git commit -m "feat: add keepalive workflow to prevent GitHub disabling scheduled jobs"
+git push
+```
+
+**Step 4: Manually trigger to verify it works**
+
+Go to `https://github.com/chardila/mybgg/actions/workflows/keepalive.yml` and click "Run workflow". Confirm the run completes successfully and an empty commit appears in the repo history.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/keepalive.yml` that runs on the 1st of every other month (Jan, Mar, May, Jul, Sep, Nov)
- Makes an empty commit as `github-actions[bot]` to keep the repository active and prevent GitHub from disabling scheduled workflows after 60 days of inactivity
- Uses explicit `git push origin HEAD:${{ github.ref_name }}` for correct behavior with branch protection rules

## Test Plan
- [ ] Trigger manually via Actions tab → Keepalive → Run workflow and confirm it completes
- [ ] Verify an empty `chore: keepalive` commit appears in the repo history after the run