### PR TITLE
chore: upgrade actions/checkout to v6 and actions/setup-python to v6 (Node 24)

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -36,10 +36,10 @@ jobs:
           fi
       - name: Checkout
         if: steps.enabled.outputs.enabled == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
         if: steps.enabled.outputs.enabled == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Empty commit to keep repo active
         run: |


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout@v4` → `@v6` in `index.yml` and `keepalive.yml`
- Upgrades `actions/setup-python@v5` → `@v6` in `index.yml`
- Both actions now use Node.js 24, eliminating the deprecation warning before the June 2, 2026 deadline

## Test Plan
- [ ] Verify the `Update gamecache.sqlite.gz with BGG data` workflow runs without Node.js 20 deprecation warnings